### PR TITLE
chore(theme): add fonts to the theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Chat Cloud</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -53,7 +53,9 @@ declare module 'styled-components' {
       button: string;
     };
     fonts: {
-      main: string;
+      CarroisGothicSCRegular: string;
+      CeraProRegular: string;
+      CeraProMedium: string;
     };
     fontSizes: {
       Regular24: string;

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -50,7 +50,9 @@ export const theme = {
     button: '13px',
   },
   fonts: {
-    main: "'Carrois Gothic', sans-serif;",
+    CarroisGothicSCRegular: "'CarroisGothicSCRegular', sans-serif;",
+    CeraProRegular: "'CeraProRegular', sans-serif;",
+    CeraProMedium: "'CeraProMedium', sans-serif;",
   },
   fontSizes: {
     Regular24: '24px',


### PR DESCRIPTION
## What?
add fonts into theme.ts and styled.d.ts

<img width="557" alt="Снимок экрана 2023-11-24 в 15 54 59" src="https://github.com/NikitOS-1/ChatCloud/assets/69642254/110014bd-0c00-423a-ae68-95af02d157bc">
<img width="467" alt="Снимок экрана 2023-11-24 в 15 55 05" src="https://github.com/NikitOS-1/ChatCloud/assets/69642254/62afe2b0-56a5-463e-b136-c94d82f3d578">

## Why?
use font from theme

## Testing / Proof
...

## How can this change be undone in case of failure?
1. Revert this PR