### PR TITLE
feat(component): create modal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,0 +1,5 @@
+import { ModalContainer } from './styled';
+import { ModalProps } from './types';
+
+export const Modal = ({ children, isOpen = false }: ModalProps) =>
+  isOpen ? <ModalContainer>{children}</ModalContainer> : null;

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,0 +1,2 @@
+export * from './Modal';
+export * from './types';

--- a/src/components/Modal/styled.ts
+++ b/src/components/Modal/styled.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+export const ModalContainer = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 9999;
+`;

--- a/src/components/Modal/types.ts
+++ b/src/components/Modal/types.ts
@@ -1,0 +1,4 @@
+export interface ModalProps {
+  children: React.ReactNode;
+  isOpen: boolean;
+}


### PR DESCRIPTION
## What?
Create RC Modal window

has props:
isOpen: boolean;
children: React.ReactNode;

## Why?
...

## Testing / Proof
<img width="777" alt="Снимок экрана 2023-11-28 в 23 58 29" src="https://github.com/NikitOS-1/ChatCloud/assets/69642254/26142052-9587-48c0-a482-b60174af3a0e">
<img width="777" alt="Снимок экрана 2023-11-28 в 23 58 11" src="https://github.com/NikitOS-1/ChatCloud/assets/69642254/f2620232-db8a-4bb9-a26b-11a3080f4deb">


## How can this change be undone in case of failure?
1. Revert this PR