### PR TITLE
refactor(component): Button types and margins

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,28 +1,17 @@
-import React from 'react';
-
 import { StyledButton } from './styled';
-import { ButtonVariantType, CONTAINED_TYPE } from './types';
-
-export interface ButtonInterface {
-  label?: string;
-  variant?: ButtonVariantType;
-  isDisabled?: boolean;
-  icon?: React.ReactNode;
-  onClick?: () => void;
-}
+import { ButtonInterface, CONTAINED_TYPE } from './types';
 
 export const Button = ({
   label,
   variant = CONTAINED_TYPE,
   isDisabled,
   icon,
-  onClick,
+  ...restProps
 }: ButtonInterface) => (
   <StyledButton
-    className="button"
+    {...restProps}
     variant={variant}
     disabled={isDisabled}
-    onClick={onClick}
     startIcon={icon}
   >
     {label}

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -1,6 +1,8 @@
 import Button from '@mui/material/Button';
 import styled, { css } from 'styled-components';
 
+import { MarginInterface } from '../../types/styles';
+
 import {
   ButtonVariantType,
   CONTAINED_TYPE,
@@ -8,7 +10,11 @@ import {
   TEXT_TYPE,
 } from './types';
 
-export const StyledButton = styled(Button)<{ variant: ButtonVariantType }>`
+interface StyledButtonInterface extends MarginInterface {
+  variant: ButtonVariantType;
+}
+
+export const StyledButton = styled(Button)<StyledButtonInterface>`
   padding: 16px 32px;
   height: 58px;
   font-family: ${({ theme }) => theme.fonts.CeraProMedium};
@@ -16,6 +22,10 @@ export const StyledButton = styled(Button)<{ variant: ButtonVariantType }>`
   border-radius: ${({ theme }) => theme.radius.button};
   text-transform: none;
   box-shadow: none;
+  margin-top: ${({ marginTop }) => marginTop};
+  margin-bottom: ${({ marginBotton }) => marginBotton};
+  margin-left: ${({ marginLeft }) => marginLeft};
+  margin-right: ${({ marginRight }) => marginRight};
 
   &:hover {
     box-shadow: none;

--- a/src/components/Button/types.ts
+++ b/src/components/Button/types.ts
@@ -1,3 +1,5 @@
+import { MarginInterface } from '../../types/styles';
+
 export const CONTAINED_TYPE = 'contained';
 export const OUTLINED_TYPE = 'outlined';
 export const TEXT_TYPE = 'text';
@@ -6,3 +8,11 @@ export type ButtonVariantType =
   | typeof CONTAINED_TYPE
   | typeof OUTLINED_TYPE
   | typeof TEXT_TYPE;
+
+export interface ButtonInterface extends MarginInterface {
+  label: string;
+  variant?: ButtonVariantType;
+  isDisabled?: boolean;
+  icon?: React.ReactNode;
+  onClick?: (event: React.MouseEvent<HTMLElement>) => void;
+}

--- a/src/types/styles.ts
+++ b/src/types/styles.ts
@@ -1,0 +1,6 @@
+export interface MarginInterface {
+  marginTop?: string;
+  marginBotton?: string;
+  marginLeft?: string;
+  marginRight?: string;
+}


### PR DESCRIPTION
## What?
Refactoring Button RC (types and margins)

## Why?
I need to control margins into Button RC

## Testing / Proof
local

## How can this change be undone in case of failure?
1. Revert this PR